### PR TITLE
Fixed issue with AngularJs failing to bootstrap

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -19,9 +19,9 @@
     <!--TEMPLATES END-->
     <!--SCRIPTS-->
     <script src="/js/dependencies/sails.io.js"></script>
+    <script src="/js/dependencies/angular.js"></script>
     <script src="/js/dependencies/angular-route.min.js"></script>
     <script src="/js/dependencies/angular-toastr.js"></script>
-    <script src="/js/dependencies/angular.js"></script>
     <script src="/js/dependencies/compareTo.module.js"></script>
     <script src="/js/dependencies/jquery-1.11.2.min.js"></script>
     <script src="/js/dependencies/lodash.js"></script>


### PR DESCRIPTION
Just going through the book and noticed that the chapter 8 examples aren't working. Found that angular-route and angular-toastr were dependent on Angular being loaded first. This change fixed it on my system.
